### PR TITLE
Add command on how to go get this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This library is a Go implementation of the [Irmin](https://github.com/mirage/irmin.git) HTTP API. The HTTP API is partly documented [here](https://github.com/mirage/irmin/wiki/REST-API). Not all calls are available in Irmin version 0.10.0 or older. `Version()` can be used to check the Irmin version.
 
+To install this library, run:
+```bash
+go get https://github.com/MagnusS/irmin-go/irmin
+```
+
 #### Examples
 
 ##### Connecting to Irmin


### PR DESCRIPTION
Just a small Readme change to indicate that you need to run 

``` bash
go get github.com/MagnusS/irmin-go/irmin
```

to get the library
instead of this one, which I tried first and didn't work because the source files are located in the `irmin` folder.

``` bash
go get github.com/MagnusS/irmin-go/
```
